### PR TITLE
Add functions for calculating derived estimates and their MOEs from

### DIFF
--- a/census_error_analyzer/__init__.py
+++ b/census_error_analyzer/__init__.py
@@ -141,7 +141,7 @@ def aggregate_counts(pairs):
     """
     estimate = 0
     squared_moe = 0
-    
+
     # Pull out the values
     for (value, moe) in pairs:
         estimate += value
@@ -239,7 +239,7 @@ def calculate_product(pair_one, pair_two):
     Examples:
         >>> calculate_product((384, 1), (0.987, 0.06))
         (379.008, 23.061131130107213)
-        
+    
     """
     # Pull out the values
     estimate_one, moe_one = pair_one
@@ -247,9 +247,9 @@ def calculate_product(pair_one, pair_two):
 
     # Calculate the product
     product_estimate = estimate_one * estimate_two
-    
-    # Calculate the product MOE
-    squared_product_moe = (estimate_one**2 * moe_two**2 +
-                           estimate_two**2 * moe_one**2)
 
-    return (products_estimate, math.sqrt(squared_product_moe))
+    # Calculate the product MOE
+    squared_product_moe = (estimate_one**2 * moe_two**2
+                           + estimate_two**2 * moe_one**2)
+
+    return (product_estimate, math.sqrt(squared_product_moe))

--- a/census_error_analyzer/__init__.py
+++ b/census_error_analyzer/__init__.py
@@ -122,7 +122,7 @@ def is_statistically_different(pair_one, pair_two):
     return statistical_difference(pair_one, pair_two) > 1.0
 
 
-def aggregate_counts(pairs):
+def calculate_sum(*pairs):
     """
     Computes a derived estimate and its MOE for the aggregation of all
     the arguments.
@@ -135,7 +135,7 @@ def aggregate_counts(pairs):
         A two-item sequence containing the aggregated estimate and its MOE.
 
     Examples:
-        >>> aggregate_counts([(379, 1), (384, 1)])
+        >>> calculate_sum((379, 1), (384, 1))
         (763, 1.4142135623730953)
 
     """
@@ -146,7 +146,6 @@ def aggregate_counts(pairs):
     for (value, moe) in pairs:
         estimate += value
         squared_moe += moe**2
-
     return (estimate, math.sqrt(squared_moe))
 
 
@@ -168,7 +167,7 @@ def calculate_proportion(numerator_pair, denominator_pair):
 
     Examples:
         >>> calculate_proportion((379, 1), (384, 1))
-        (0.9869791666666666, 0.02046644492870734)
+        (0.9869791666666666, 0.008208247339752435)
 
     """
     # Pull out the values
@@ -176,10 +175,10 @@ def calculate_proportion(numerator_pair, denominator_pair):
     denominator_estimate, denominator_moe = denominator_pair
 
     # Calculate the proportion
-    proportion_estimate = numerator_estimate / denominator_estimate
+    proportion_estimate = 1.0 * numerator_estimate / denominator_estimate
 
     # Calculate the proportion MOE
-    squared_proportion_moe = (
+    squared_proportion_moe = 1.0 * (
         numerator_moe**2 - proportion_estimate**2 * denominator_moe**2
     ) / denominator_estimate
 
@@ -204,7 +203,7 @@ def calculate_ratio(numerator_pair, denominator_pair):
 
     Examples:
         >>> calculate_ratio((379, 1), (384, 1))
-        (0.9869791666666666, 0.0604892511542549)
+        (0.9869791666666666, 0.07170047425884142)
     """
     # Pull out the values
     numerator_estimate, numerator_moe = numerator_pair
@@ -214,7 +213,7 @@ def calculate_ratio(numerator_pair, denominator_pair):
     ratio_estimate = numerator_estimate / denominator_estimate
 
     # Calculate the ratio MOE
-    squared_ratio_moe = (
+    squared_ratio_moe = 1.0 * (
         numerator_moe**2 + ratio_estimate**2 * denominator_moe**2
     ) / denominator_estimate
 
@@ -239,7 +238,7 @@ def calculate_product(pair_one, pair_two):
     Examples:
         >>> calculate_product((384, 1), (0.987, 0.06))
         (379.008, 23.061131130107213)
-    
+
     """
     # Pull out the values
     estimate_one, moe_one = pair_one
@@ -249,7 +248,6 @@ def calculate_product(pair_one, pair_two):
     product_estimate = estimate_one * estimate_two
 
     # Calculate the product MOE
-    squared_product_moe = (estimate_one**2 * moe_two**2
-                           + estimate_two**2 * moe_one**2)
+    squared_product_moe = estimate_one**2 * moe_two**2 + estimate_two**2 * moe_one**2
 
     return (product_estimate, math.sqrt(squared_product_moe))

--- a/census_error_analyzer/__init__.py
+++ b/census_error_analyzer/__init__.py
@@ -120,3 +120,136 @@ def is_statistically_different(pair_one, pair_two):
         True
     """
     return statistical_difference(pair_one, pair_two) > 1.0
+
+
+def aggregate_counts(pairs):
+    """
+    Computes a derived estimate and its MOE for the aggregation of all
+    the arguments.
+
+    Args:
+        pairs (list): a list of two-item sequences with a U.S. Census bureau
+            count estimate and its margin of error.
+
+    Returns:
+        A two-item sequence containing the aggregated estimate and its MOE.
+
+    Examples:
+        >>> aggregate_counts([(379, 1), (384, 1)])
+        (763, 1.4142135623730953)
+
+    """
+    estimate = 0
+    squared_moe = 0
+    
+    # Pull out the values
+    for (value, moe) in pairs:
+        estimate += value
+        squared_moe += moe**2
+
+    return (estimate, math.sqrt(squared_moe))
+
+
+def calculate_proportion(numerator_pair, denominator_pair):
+    """
+    Computes a derived estimate and its MOE for the proportion between
+    the numerator and denominator arguments where the numerator
+    represents a subset of the denominator.
+
+    Args:
+        numerator (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+        denominator (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+    Returns:
+        A two-item sequence containing the calculated estimate and its MOE.
+
+    Examples:
+        >>> calculate_proportion((379, 1), (384, 1))
+        (0.9869791666666666, 0.02046644492870734)
+
+    """
+    # Pull out the values
+    numerator_estimate, numerator_moe = numerator_pair
+    denominator_estimate, denominator_moe = denominator_pair
+
+    # Calculate the proportion
+    proportion_estimate = numerator_estimate / denominator_estimate
+
+    # Calculate the proportion MOE
+    squared_proportion_moe = (
+        numerator_moe**2 - proportion_estimate**2 * denominator_moe**2
+    ) / denominator_estimate
+
+    return (proportion_estimate, math.sqrt(squared_proportion_moe))
+
+
+def calculate_ratio(numerator_pair, denominator_pair):
+    """
+    Computes a derived estimate and its MOE for the ratio between
+    the numerator and denominator arguments where the numerator
+    does not represent a subset of the denominator.
+
+    Args:
+        numerator (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+        denominator (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+    Returns:
+        A two-item sequence containing the calculated estimate and its MOE.
+
+    Examples:
+        >>> calculate_ratio((379, 1), (384, 1))
+        (0.9869791666666666, 0.0604892511542549)
+    """
+    # Pull out the values
+    numerator_estimate, numerator_moe = numerator_pair
+    denominator_estimate, denominator_moe = denominator_pair
+
+    # Calculate the ratio
+    ratio_estimate = numerator_estimate / denominator_estimate
+
+    # Calculate the ratio MOE
+    squared_ratio_moe = (
+        numerator_moe**2 + ratio_estimate**2 * denominator_moe**2
+    ) / denominator_estimate
+
+    return (ratio_estimate, math.sqrt(squared_ratio_moe))
+
+
+def calculate_product(pair_one, pair_two):
+    """
+    Computes a derived estimate and its MOE for the product between
+    the arguments.
+
+    Args:
+        pair_one (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+        pair_two (list): a two-item sequence with a U.S. Census
+            bureau estimate and its margin of error.
+
+    Returns:
+        A two-item sequence containing the calculated estimate and its MOE.
+
+    Examples:
+        >>> calculate_product((384, 1), (0.987, 0.06))
+        (379.008, 23.061131130107213)
+        
+    """
+    # Pull out the values
+    estimate_one, moe_one = pair_one
+    estimate_two, moe_two = pair_two
+
+    # Calculate the product
+    product_estimate = estimate_one * estimate_two
+    
+    # Calculate the product MOE
+    squared_product_moe = (estimate_one**2 * moe_two**2 +
+                           estimate_two**2 * moe_one**2)
+
+    return (products_estimate, math.sqrt(squared_product_moe))

--- a/test.py
+++ b/test.py
@@ -29,6 +29,25 @@ class CensusErrorAnalyzerTest(unittest.TestCase):
         self.assertTrue(census_error_analyzer.is_statistically_different((37.9, 0.1), (38.4, 0.1)))
         self.assertFalse(census_error_analyzer.is_statistically_different((37284, 20922), (76850, 47200)))
 
+    def test_sum(self):
+        estimate, moe = census_error_analyzer.calculate_sum((379, 1), (384, 1))
+        self.assertAlmostEqual(estimate, 763)
+        self.assertAlmostEqual(moe, 1.4142135623730951)
+
+    def test_proportion(self):
+        estimate, moe = census_error_analyzer.calculate_proportion((379, 1), (384, 1))
+        self.assertAlmostEqual(estimate, 0.9869791666666666)
+        self.assertAlmostEqual(moe, 0.008208247339752435)
+
+    def test_ratio(self):
+        estimate, moe = census_error_analyzer.calculate_ratio((379, 1), (384, 1))
+        self.assertAlmostEqual(estimate, 0.9869791666666666)
+        self.assertAlmostEqual(moe, 0.07170047425884142)
+
+    def test_product(self):
+        estimate, moe = census_error_analyzer.calculate_product((384, 1), (0.987, 0.06))
+        self.assertAlmostEqual(estimate, 379.008)
+        self.assertAlmostEqual(moe, 23.061131130107213)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds functions for calculating derived estimates and their MOEs using the formulas provided in Chapter 8 of the ACS General Handbook.
https://www.census.gov/content/dam/Census/library/publications/2018/acs/acs_general_handbook_2018_ch08.pdf